### PR TITLE
Capitalizes UserId in findAll for favorites get request

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -51,7 +51,7 @@ router.get("/", function(req,res,next) {
     if (user) {
       UserCity.findAll({
         where: {
-          userId: user["dataValues"]["id"]
+          UserId: user["dataValues"]["id"]
         }
         // include: [{model: City}]
       })


### PR DESCRIPTION
The heroku logs say there is no such column as userId ("maybe you mean UserId"), so in the get request for favorites, in the UserCity.findAll, this changes userId to UserId.

Let's hope this fixes the issue.